### PR TITLE
Changed `Questionnaire_EnableWhenOperatorKind` to match FHIR R4 spec

### DIFF
--- a/src/R4/Resource/RTTI_Questionnaire_EnableWhen.ts
+++ b/src/R4/Resource/RTTI_Questionnaire_EnableWhen.ts
@@ -6,12 +6,12 @@ import { RTTI_Quantity, IQuantity } from './RTTI_Quantity';
 import { RTTI_Reference, IReference } from './RTTI_Reference';
 export enum Questionnaire_EnableWhenOperatorKind {
 	_exists = 'exists',
-	_equal = 'Equal',
-	_notEqual = 'NotEqual',
-	_greater = 'Greater',
-	_lower = 'Lower',
-	_greaterOrEqual = 'GreaterOrEqual',
-	_lowerOrEqual = 'LowerOrEqual'
+	_equal = '=',
+	_notEqual = '!=',
+	_greater = '>',
+	_lower = '<',
+	_greaterOrEqual = '>=',
+	_lowerOrEqual = '<='
 }
 import { createEnumType } from '../../EnumType';
 


### PR DESCRIPTION
Changes the type `Questionnaire_EnableWhenOperatorKind` to use symbols ("=", ">") instead of words ("Equal", "Greater", ...). The spec uses symbols.

See the spec here:
https://www.hl7.org/fhir/questionnaire-definitions.html#Questionnaire.item.enableWhen.operator